### PR TITLE
fix: move Copper from ecosystem to use-cases

### DIFF
--- a/src/content/de/ecosystem.json
+++ b/src/content/de/ecosystem.json
@@ -15,8 +15,7 @@
 		"Tokenization",
 		"On-and Offramp",
 		"DEX",
-		"Wallet",
-		"Custody"
+		"Wallet"
 	],
 	"tabs": [
 		{
@@ -107,16 +106,6 @@
 			"category": "Wallet",
 			"description": "Die Frankencoin App ist eine selbstverwahrende Wallet, die von DFX.swiss betrieben wird. Sie ermöglicht es Benutzern, FPS, ZCHF oder andere Kryptowährungen einfach per Banküberweisung zu kaufen, Zahlungen zu senden oder zu empfangen und vieles mehr in kommenden Updates.",
 			"linkLabel": "frankencoin.app"
-		},
-		{
-			"href": "https://copper.co/",
-			"name": "Copper",
-			"image": "/images/CopperLogoDark.png",
-			"imageAlt": "Copper Logo",
-			"badge": "Custody",
-			"category": "Custody",
-			"description": "ZCHF wird durch die institutionelle Custody- und Collateral-Management-Infrastruktur von Copper unterstützt.",
-			"linkLabel": "copper.co"
 		}
 	]
 }

--- a/src/content/de/use-cases.json
+++ b/src/content/de/use-cases.json
@@ -90,6 +90,14 @@
 			"category": "Business",
 			"image": "/images/bitcoin-suisse.png",
 			"link": "https://www.bitcoinsuisse.com/"
+		},
+		{
+			"title": "Institutionelle Verwahrung & Collateral Management",
+			"partner": "Copper",
+			"description": "ZCHF wird durch die institutionelle Custody- und Collateral-Management-Infrastruktur von Copper unterstützt – für sichere Verwahrung und DeFi-fähigen Einsatz von Schweizer-Franken-Liquidität.",
+			"category": "Business",
+			"image": "/images/CopperLogoDark.png",
+			"link": "https://copper.co/"
 		}
 	]
 }

--- a/src/content/en/ecosystem.json
+++ b/src/content/en/ecosystem.json
@@ -15,8 +15,7 @@
 		"Tokenization",
 		"On-and Offramp",
 		"DEX",
-		"Wallet",
-		"Custody"
+		"Wallet"
 	],
 	"tabs": [
 		{
@@ -107,16 +106,6 @@
 			"category": "Wallet",
 			"description": "Frankencoin App is a self-custody wallet powered by DFX.swiss. It allows users to easily buy FPS, ZCHF or other cryptocurrencies via bank transfer, send or receive payments and much more in upcoming updates.",
 			"linkLabel": "frankencoin.app"
-		},
-		{
-			"href": "https://copper.co/",
-			"name": "Copper",
-			"image": "/images/CopperLogoDark.png",
-			"imageAlt": "Copper Logo",
-			"badge": "Custody",
-			"category": "Custody",
-			"description": "ZCHF is supported by Copper's institutional custody & collateral management infrastructure.",
-			"linkLabel": "copper.co"
 		}
 	]
 }

--- a/src/content/en/use-cases.json
+++ b/src/content/en/use-cases.json
@@ -90,6 +90,14 @@
 			"category": "Business",
 			"image": "/images/bitcoin-suisse.png",
 			"link": "https://www.bitcoinsuisse.com/"
+		},
+		{
+			"title": "Institutional Custody & Collateral Management",
+			"partner": "Copper",
+			"description": "ZCHF is supported by Copper's institutional custody and collateral management infrastructure — enabling secure holding and DeFi-ready deployment of Swiss franc liquidity.",
+			"category": "Business",
+			"image": "/images/CopperLogoDark.png",
+			"link": "https://copper.co/"
 		}
 	]
 }

--- a/src/content/fr/ecosystem.json
+++ b/src/content/fr/ecosystem.json
@@ -15,8 +15,7 @@
 		"Tokenization",
 		"On-and Offramp",
 		"DEX",
-		"Wallet",
-		"Custody"
+		"Wallet"
 	],
 	"tabs": [
 		{
@@ -107,16 +106,6 @@
 			"category": "Wallet",
 			"description": "Frankencoin App est un portefeuille auto-gardé alimenté par DFX.swiss. Il permet aux utilisateurs d'acheter facilement des FPS, ZCHF ou d'autres cryptomonnaies par virement bancaire, d'envoyer ou de recevoir des paiements et bien plus encore dans les prochaines mises à jour.",
 			"linkLabel": "frankencoin.app"
-		},
-		{
-			"href": "https://copper.co/",
-			"name": "Copper",
-			"image": "/images/CopperLogoDark.png",
-			"imageAlt": "Copper Logo",
-			"badge": "Custody",
-			"category": "Custody",
-			"description": "ZCHF est pris en charge par l'infrastructure de conservation institutionnelle et de gestion des garanties de Copper.",
-			"linkLabel": "copper.co"
 		}
 	]
 }

--- a/src/content/fr/use-cases.json
+++ b/src/content/fr/use-cases.json
@@ -90,6 +90,14 @@
 			"category": "Business",
 			"image": "/images/bitcoin-suisse.png",
 			"link": "https://www.bitcoinsuisse.com/"
+		},
+		{
+			"title": "Conservation Institutionnelle & Gestion des Garanties",
+			"partner": "Copper",
+			"description": "ZCHF est pris en charge par l'infrastructure de conservation institutionnelle et de gestion des garanties de Copper, permettant une détention sécurisée et un déploiement DeFi des liquidités en francs suisses.",
+			"category": "Business",
+			"image": "/images/CopperLogoDark.png",
+			"link": "https://copper.co/"
 		}
 	]
 }


### PR DESCRIPTION
## What

Copper was incorrectly placed in `ecosystem.json` under a new "Custody" category tab. It should be in `use-cases.json` alongside Bitcoin Suisse and other institutional partners.

## Changes
- Removed Copper entry + "Custody" category from `ecosystem.json` (en/de/fr)
- Added Copper entry to `use-cases.json` (en/de/fr) under "Business" category

**Replaces:** PR #5 (which has been merged — this corrects the placement)
