### PR TITLE
feat: add CoinTelegraph CHFAU article to media section

### DIFF
--- a/src/content/shared/media.json
+++ b/src/content/shared/media.json
@@ -1,6 +1,7 @@
 {
 	"_comment": "This file contains media content (articles and videos) and manual metadata overrides. Open Graph data is fetched by default for articles. Only add manual overrides when you need to override specific fields.",
 	"articles": [
+		"https://cointelegraph.com/news/allunity-swiss-franc-stablecoin-chfau-mica",
 		"https://www.nzz.ch/wirtschaft/der-digitale-franken-ist-da-aber-er-stammt-aus-deutschland-schweizer-anbieter-haben-keine-chance-ld.1926730",
 		"https://www.tippinpoint.ch/artikel/78597/den_zins_des_stablecoins_entfesseln.html",
 		"https://www.finews.ch/news/finanzplatz/70983-stablecoin-frankencoin-plusplus-finanzprodukte-etp-treasury-liquiditaetsbewirtschaftung-mietkaution-finanzplatz-schweiz",
@@ -28,11 +29,11 @@
 	],
 	"articleMetadata": {
 		"https://www.nzz.ch/wirtschaft/der-digitale-franken-ist-da-aber-er-stammt-aus-deutschland-schweizer-anbieter-haben-keine-chance-ld.1926730": {
-  "title": "Der digitale Franken kommt aus Deutschland. Schweizer Anbieter haben keine Chance",
-  "description": "Strenge Geldwäschereivorgaben verunmöglichen es Schweizer Firmen, einen Franken-Stablecoin zu lancieren. Nun bringt ein deutsches Unternehmen einen digitalen Franken auf den Markt – gestützt auf EU-Recht.",
-  "siteName": "NZZ",
-  "publishedDate": "Feb 27, 2026"
-},
+			"title": "Der digitale Franken kommt aus Deutschland. Schweizer Anbieter haben keine Chance",
+			"description": "Strenge Geldwäschereivorgaben verunmöglichen es Schweizer Firmen, einen Franken-Stablecoin zu lancieren. Nun bringt ein deutsches Unternehmen einen digitalen Franken auf den Markt – gestützt auf EU-Recht.",
+			"siteName": "NZZ",
+			"publishedDate": "Feb 27, 2026"
+		},
 		"https://www.tippinpoint.ch/artikel/78597/den_zins_des_stablecoins_entfesseln.html": {
 			"title": "Den Zins des Stablecoins entfesseln",
 			"description": "Die Schweiz tritt mit Verspätung in den Stablecoin-Markt ein. Die hohen Renditen der Stablecoins fliessen an schlecht regulierte ausländische Firmen. Frankencoin und Plusplus AG wollen das ändern.",
@@ -106,6 +107,12 @@
 		},
 		"https://www.schweizeraktien.net/blog/2024/06/17/aktionariat-ein-neuer-handelsplatz-fuer-aktien-token-und-darin-integriert-der-frankencoin-63687/": {
 			"publishedDate": "Jun 17, 2024"
+		},
+		"https://cointelegraph.com/news/allunity-swiss-franc-stablecoin-chfau-mica": {
+			"title": "AllUnity Launches Swiss Franc Stablecoin CHFAU",
+			"description": "Deutsche Bank-backed AllUnity launches MiCA-compliant CHFAU. Frankencoin (ZCHF) named the largest CHF stablecoin with $38.6M combined market cap.",
+			"siteName": "CoinTelegraph",
+			"publishedDate": "Feb 26, 2026"
 		}
 	},
 	"videoMetadata": {


### PR DESCRIPTION
Adds the CoinTelegraph article on AllUnity's CHFAU launch — Frankencoin (ZCHF) is highlighted as the largest CHF stablecoin at $38.6M market cap.

https://cointelegraph.com/news/allunity-swiss-franc-stablecoin-chfau-mica