### PR TITLE
content: add merch.frankencoin.com to footer

### DIFF
--- a/src/content/de/shared/footer.json
+++ b/src/content/de/shared/footer.json
@@ -117,6 +117,11 @@
             "label": "Veranstaltungen",
             "href": "https://luma.com/user/frankencoin",
             "external": true
+          },
+          {
+            "label": "Merch",
+            "href": "https://merch.frankencoin.com",
+            "external": true
           }
         ]
       }

--- a/src/content/en/shared/footer.json
+++ b/src/content/en/shared/footer.json
@@ -117,6 +117,11 @@
             "label": "Upcoming Events",
             "href": "https://luma.com/frankencoin",
             "external": true
+          },
+          {
+            "label": "Merch",
+            "href": "https://merch.frankencoin.com",
+            "external": true
           }
         ]
       }

--- a/src/content/fr/shared/footer.json
+++ b/src/content/fr/shared/footer.json
@@ -117,6 +117,11 @@
             "label": "Événements à venir",
             "href": "https://luma.com/user/frankencoin",
             "external": true
+          },
+          {
+            "label": "Merch",
+            "href": "https://merch.frankencoin.com",
+            "external": true
           }
         ]
       }


### PR DESCRIPTION
Adds a **Merch** link (`https://merch.frankencoin.com`) to the Community section of the footer across all three languages (en/de/fr).