### PR TITLE
feat: add MCP server link to footer developers section

### DIFF
--- a/src/content/de/shared/footer.json
+++ b/src/content/de/shared/footer.json
@@ -74,6 +74,11 @@
             "external": true
           },
           {
+            "label": "MCP Server",
+            "href": "https://mcp.frankencoin.com",
+            "external": true
+          },
+          {
             "label": "Frankencoin Whitepaper",
             "href": "https://app.frankencoin.com/thesis-frankencoin.pdf",
             "external": true

--- a/src/content/en/shared/footer.json
+++ b/src/content/en/shared/footer.json
@@ -74,6 +74,11 @@
             "external": true
           },
           {
+            "label": "MCP Server",
+            "href": "https://mcp.frankencoin.com",
+            "external": true
+          },
+          {
             "label": "Frankencoin Whitepaper",
             "href": "https://app.frankencoin.com/thesis-frankencoin.pdf",
             "external": true

--- a/src/content/fr/shared/footer.json
+++ b/src/content/fr/shared/footer.json
@@ -74,6 +74,11 @@
             "external": true
           },
           {
+            "label": "MCP Server",
+            "href": "https://mcp.frankencoin.com",
+            "external": true
+          },
+          {
             "label": "Livre blanc Frankencoin",
             "href": "https://app.frankencoin.com/thesis-frankencoin.pdf",
             "external": true


### PR DESCRIPTION
Adds `mcp.frankencoin.com` as a link in the Developers section of the footer (all 3 languages: EN/DE/FR), placed after the API link.