### PR TITLE
fix: broken links in FAQ (en/de/fr)

### DIFF
--- a/src/content/de/faq.json
+++ b/src/content/de/faq.json
@@ -35,7 +35,7 @@
 				},
 				{
 					"question": "Was passiert, wenn die Collaterals an Wert verlieren?",
-					"answer": "Das System verfügt über mehrere Sicherheitsebenen: individuelle Positionsreserven, den [FPS-Reservepool](/#foundation) und automatisierte [Liquidationsmechanismen](https://docs.frankencoin.com/positions/liquidation). Wenn Sicherheiten unter sichere Niveaus fallen, werden Positionen liquidiert, um die Überbesicherung aufrechtzuerhalten."
+					"answer": "Das System verfügt über mehrere Sicherheitsebenen: individuelle Positionsreserven, den [FPS-Reservepool](/#foundation) und automatisierte [Liquidationsmechanismen](https://docs.frankencoin.com/positions/auctions). Wenn Sicherheiten unter sichere Niveaus fallen, werden Positionen liquidiert, um die Überbesicherung aufrechtzuerhalten."
 				},
 				{
 					"question": "Was sind Frankencoin Pool Shares (FPS)?",
@@ -43,7 +43,7 @@
 				},
 				{
 					"question": "Kann Frankencoin seine Bindung zum Schweizer Franken verlieren?",
-					"answer": "Obwohl ZCHF darauf ausgelegt ist, CHF 1:1 zu folgen, kann er aufgrund von Marktdynamiken vorübergehend leicht über oder unter der Bindung gehandelt werden. [Arbitrage-Mechanismen](https://docs.frankencoin.com/positions/minting) und wirtschaftliche Anreize wirken darauf hin, die Bindung wiederherzustellen. Die langfristige Stabilität hängt von ausreichender [Besicherung](/#how-does-it-work) ab."
+					"answer": "Obwohl ZCHF darauf ausgelegt ist, CHF 1:1 zu folgen, kann er aufgrund von Marktdynamiken vorübergehend leicht über oder unter der Bindung gehandelt werden. [Arbitrage-Mechanismen](https://docs.frankencoin.com/positions) und wirtschaftliche Anreize wirken darauf hin, die Bindung wiederherzustellen. Die langfristige Stabilität hängt von ausreichender [Besicherung](/#how-does-it-work) ab."
 				}
 			]
 		},
@@ -60,7 +60,7 @@
 				},
 				{
 					"question": "Kann ich Zinsen auf meine Frankencoin verdienen?",
-					"answer": "Sie können Rendite erzielen, indem Sie [Liquidität für DeFi-Protokolle bereitstellen](https://app.morpho.org/ethereum/earn?assetIdsFilter=ecc8bd13-eab5-4c7b-97e1-ba23d58f8cd3&vaultV2Filter=false) wie Morpho oder das [Frankencoin-Sparmodul](https://https://app.frankencoin.com/savings) nutzen. Die Renditen variieren je nach Marktbedingungen und sind nicht garantiert. Die Zinssätze spiegeln Angebot und Nachfrage nach CHF-Liquidität in dezentralen Märkten wider."
+					"answer": "Sie können Rendite erzielen, indem Sie [Liquidität für DeFi-Protokolle bereitstellen](https://app.morpho.org/ethereum/earn?assetIdsFilter=ecc8bd13-eab5-4c7b-97e1-ba23d58f8cd3&vaultV2Filter=false) wie Morpho oder das [Frankencoin-Sparmodul](https://app.frankencoin.com/savings) nutzen. Die Renditen variieren je nach Marktbedingungen und sind nicht garantiert. Die Zinssätze spiegeln Angebot und Nachfrage nach CHF-Liquidität in dezentralen Märkten wider."
 				}
 			]
 		},
@@ -81,7 +81,7 @@
 				},
 				{
 					"question": "Wurde Frankencoin auditiert?",
-					"answer": "Ja, die Smart Contracts wurden von mehreren führenden Blockchain-Sicherheitsfirmen geprüft, darunter [Code4rena](https://code4rena.com/reports/2023-04-frankencoin), [BlockBite](/AuditReport-Frankencoin.pdf) und [ChainSecurity](https://chainsecurity.com/security-audit/frankencoin/). [Prüfberichte](/#trust-security) sind öffentlich verfügbar."
+					"answer": "Ja, die Smart Contracts wurden von mehreren führenden Blockchain-Sicherheitsfirmen geprüft, darunter [Code4rena](https://code4rena.com/reports/2023-04-frankencoin), [BlockBite](/AuditReport-Frankencoin.pdf) und [ChainSecurity](https://www.chainsecurity.com/security-audit/frankencoin-smart-contracts). [Prüfberichte](/#trust-security) sind öffentlich verfügbar."
 				}
 			]
 		}

--- a/src/content/en/faq.json
+++ b/src/content/en/faq.json
@@ -35,7 +35,7 @@
 				},
 				{
 					"question": "What happens if the collateral loses value?",
-					"answer": "The system has multiple safety layers: individual position reserves, the [FPS reserve pool](/#foundation), and automated [liquidation mechanisms](https://docs.frankencoin.com/positions/liquidation). If collateral drops below safe levels, positions are liquidated to maintain over-collateralization."
+					"answer": "The system has multiple safety layers: individual position reserves, the [FPS reserve pool](/#foundation), and automated [liquidation mechanisms](https://docs.frankencoin.com/positions/auctions). If collateral drops below safe levels, positions are liquidated to maintain over-collateralization."
 				},
 				{
 					"question": "What are Frankencoin Pool Shares (FPS)?",
@@ -43,7 +43,7 @@
 				},
 				{
 					"question": "Can Frankencoin lose its peg to the Swiss franc?",
-					"answer": "While designed to track CHF 1:1, ZCHF can temporarily trade slightly above or below peg due to market dynamics. [Arbitrage mechanisms](https://docs.frankencoin.com/positions/minting) and economic incentives work to restore the peg. Long-term stability depends on adequate [collateralization](/#how-does-it-work)."
+					"answer": "While designed to track CHF 1:1, ZCHF can temporarily trade slightly above or below peg due to market dynamics. [Arbitrage mechanisms](https://docs.frankencoin.com/positions) and economic incentives work to restore the peg. Long-term stability depends on adequate [collateralization](/#how-does-it-work)."
 				}
 			]
 		},
@@ -60,7 +60,7 @@
 				},
 				{
 					"question": "Can I earn interest on my Frankencoin?",
-					"answer": "You can earn yield by [providing liquidity to DeFi protocols](https://app.morpho.org/ethereum/earn?assetIdsFilter=ecc8bd13-eab5-4c7b-97e1-ba23d58f8cd3&vaultV2Filter=false) like morpho or using the [Frankencoin savings module](https://https://app.frankencoin.com/savings). Returns vary based on market conditions and are not guaranteed. Rates reflect supply and demand for CHF liquidity in decentralized markets."
+					"answer": "You can earn yield by [providing liquidity to DeFi protocols](https://app.morpho.org/ethereum/earn?assetIdsFilter=ecc8bd13-eab5-4c7b-97e1-ba23d58f8cd3&vaultV2Filter=false) like morpho or using the [Frankencoin savings module](https://app.frankencoin.com/savings). Returns vary based on market conditions and are not guaranteed. Rates reflect supply and demand for CHF liquidity in decentralized markets."
 				}
 			]
 		},
@@ -81,7 +81,7 @@
 				},
 				{
 					"question": "Has Frankencoin been audited?",
-					"answer": "Yes, the smart contracts have been audited by multiple leading blockchain security firms including [Code4rena](https://code4rena.com/reports/2023-04-frankencoin), [BlockBite](/AuditReport-Frankencoin.pdf), and [ChainSecurity](https://chainsecurity.com/security-audit/frankencoin/). [Audit reports](/#trust-security) are publicly available."
+					"answer": "Yes, the smart contracts have been audited by multiple leading blockchain security firms including [Code4rena](https://code4rena.com/reports/2023-04-frankencoin), [BlockBite](/AuditReport-Frankencoin.pdf), and [ChainSecurity](https://www.chainsecurity.com/security-audit/frankencoin-smart-contracts). [Audit reports](/#trust-security) are publicly available."
 				}
 			]
 		}

--- a/src/content/fr/faq.json
+++ b/src/content/fr/faq.json
@@ -35,7 +35,7 @@
 				},
 				{
 					"question": "Que se passe-t-il si les garanties perdent de la valeur ?",
-					"answer": "Le système dispose de plusieurs couches de sécurité : les réserves de positions individuelles, le [pool de réserve FPS](/#foundation) et les [mécanismes de liquidation](https://docs.frankencoin.com/positions/liquidation) automatisés. Si les garanties tombent en dessous de niveaux sûrs, les positions sont liquidées pour maintenir la sur-collatéralisation."
+					"answer": "Le système dispose de plusieurs couches de sécurité : les réserves de positions individuelles, le [pool de réserve FPS](/#foundation) et les [mécanismes de liquidation](https://docs.frankencoin.com/positions/auctions) automatisés. Si les garanties tombent en dessous de niveaux sûrs, les positions sont liquidées pour maintenir la sur-collatéralisation."
 				},
 				{
 					"question": "Que sont les Frankencoin Pool Shares (FPS) ?",
@@ -43,7 +43,7 @@
 				},
 				{
 					"question": "Frankencoin peut-il perdre son ancrage au franc suisse ?",
-					"answer": "Bien que conçu pour suivre le CHF 1:1, le ZCHF peut temporairement se négocier légèrement au-dessus ou en dessous de l'ancrage en raison de la dynamique du marché. Les [mécanismes d'arbitrage](https://docs.frankencoin.com/positions/minting) et les incitations économiques travaillent à restaurer l'ancrage. La stabilité à long terme dépend d'une [collatéralisation](/#how-does-it-work) adéquate."
+					"answer": "Bien que conçu pour suivre le CHF 1:1, le ZCHF peut temporairement se négocier légèrement au-dessus ou en dessous de l'ancrage en raison de la dynamique du marché. Les [mécanismes d'arbitrage](https://docs.frankencoin.com/positions) et les incitations économiques travaillent à restaurer l'ancrage. La stabilité à long terme dépend d'une [collatéralisation](/#how-does-it-work) adéquate."
 				}
 			]
 		},
@@ -60,7 +60,7 @@
 				},
 				{
 					"question": "Puis-je gagner des intérêts sur mes Frankencoin ?",
-					"answer": "Vous pouvez gagner un rendement en [fournissant de la liquidité aux protocoles DeFi](https://app.morpho.org/ethereum/earn?assetIdsFilter=ecc8bd13-eab5-4c7b-97e1-ba23d58f8cd3&vaultV2Filter=false) comme Morpho ou en utilisant le [module d'épargne Frankencoin](https://https://app.frankencoin.com/savings). Les rendements varient en fonction des conditions du marché et ne sont pas garantis. Les taux reflètent l'offre et la demande de liquidité CHF sur les marchés décentralisés."
+					"answer": "Vous pouvez gagner un rendement en [fournissant de la liquidité aux protocoles DeFi](https://app.morpho.org/ethereum/earn?assetIdsFilter=ecc8bd13-eab5-4c7b-97e1-ba23d58f8cd3&vaultV2Filter=false) comme Morpho ou en utilisant le [module d'épargne Frankencoin](https://app.frankencoin.com/savings). Les rendements varient en fonction des conditions du marché et ne sont pas garantis. Les taux reflètent l'offre et la demande de liquidité CHF sur les marchés décentralisés."
 				}
 			]
 		},
@@ -81,7 +81,7 @@
 				},
 				{
 					"question": "Frankencoin a-t-il été audité ?",
-					"answer": "Oui, les smart contracts ont été audités par plusieurs entreprises de sécurité blockchain de premier plan, notamment [Code4rena](https://code4rena.com/reports/2023-04-frankencoin), [BlockBite](/AuditReport-Frankencoin.pdf) et [ChainSecurity](https://chainsecurity.com/security-audit/frankencoin/). Les [rapports d'audit](/#trust-security) sont publiquement disponibles."
+					"answer": "Oui, les smart contracts ont été audités par plusieurs entreprises de sécurité blockchain de premier plan, notamment [Code4rena](https://code4rena.com/reports/2023-04-frankencoin), [BlockBite](/AuditReport-Frankencoin.pdf) et [ChainSecurity](https://www.chainsecurity.com/security-audit/frankencoin-smart-contracts). Les [rapports d'audit](/#trust-security) sont publiquement disponibles."
 				}
 			]
 		}


### PR DESCRIPTION
## Fixes (all 3 languages)

| # | Broken | Fix |
|---|--------|-----|
| 1 | `https://https://app.frankencoin.com/savings` (double https typo) | `https://app.frankencoin.com/savings` |
| 2 | `docs.frankencoin.com/positions/liquidation` (404) | `docs.frankencoin.com/positions/auctions` |
| 3 | `docs.frankencoin.com/positions/minting` (404) | `docs.frankencoin.com/positions` |
| 4 | `chainsecurity.com/security-audit/frankencoin/` (404) | `www.chainsecurity.com/security-audit/frankencoin-smart-contracts` |

All fixes applied to `src/content/{en,de,fr}/faq.json`.