### PR TITLE
feat: add Frankencoin Frontends page + home page callout

### DIFF
--- a/src/components/Frontends/FrontendCard.astro
+++ b/src/components/Frontends/FrontendCard.astro
@@ -1,0 +1,157 @@
+---
+import Button from "../Button/Button.astro";
+
+type FeatureKey =
+  | "openSource"
+  | "ownDomain"
+  | "selfHostedApi"
+  | "selfHostedIndexer";
+
+interface Props {
+  name: string;
+  url: string;
+  creator: string;
+  creatorUrl: string;
+  repo: string;
+  notes: string;
+  features: Record<FeatureKey, boolean>;
+  labels: {
+    creator: string;
+    repo: string;
+    live: string;
+    features: string;
+    openSource: string;
+    ownDomain: string;
+    selfHostedApi: string;
+    selfHostedIndexer: string;
+  };
+}
+
+const {
+  name,
+  url,
+  creator,
+  creatorUrl,
+  repo,
+  notes,
+  features,
+  labels,
+} = Astro.props as Props;
+
+const displayUrl = url.replace(/^https?:\/\//, "").replace(/\/$/, "");
+
+const featureOrder: FeatureKey[] = [
+  "openSource",
+  "ownDomain",
+  "selfHostedApi",
+  "selfHostedIndexer",
+];
+---
+
+<article
+  class="rounded-xl shadow-sm hover:shadow-md bg-[var(--color-white)] border border-[var(--color-neutral-200)] transition flex flex-col gap-[var(--spacing-l)] p-[var(--spacing-xl)] md:p-[var(--spacing-xxl)]"
+>
+  <header class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-[var(--spacing-l)]">
+    <div class="flex flex-col gap-[var(--spacing-xs)] min-w-0">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="ty-title-2 text-[var(--color-brand-deep-blue)] hover:text-[var(--color-brand-swiss)] font-bold break-all"
+      >
+        {displayUrl}
+      </a>
+      <p class="ty-body-2 text-[var(--color-neutral-650)]">
+        <span>{labels.creator}</span>
+        {" "}
+        <a
+          href={creatorUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-[var(--color-brand-deep-blue)] hover:text-[var(--color-brand-swiss)] font-semibold"
+        >
+          {creator}
+        </a>
+      </p>
+    </div>
+
+    <div class="flex flex-wrap gap-[var(--spacing-s)] shrink-0">
+      <Button
+        href={url}
+        variant="primary"
+        rounded="full"
+        size="md"
+        external={true}
+      >
+        {labels.live}
+        <img
+          slot="icon-right"
+          src="/images/Arrow.svg"
+          loading="lazy"
+          alt=""
+          class="w-3 h-3 ml-1"
+        />
+      </Button>
+      <Button
+        href={repo}
+        variant="secondary"
+        rounded="full"
+        size="md"
+        external={true}
+      >
+        {labels.repo}
+        <img
+          slot="icon-right"
+          src="/images/Arrow.svg"
+          loading="lazy"
+          alt=""
+          class="w-3 h-3 ml-1"
+        />
+      </Button>
+    </div>
+  </header>
+
+  <p class="ty-body-1 text-[var(--color-neutral-700)] max-w-[68ch]">
+    {notes}
+  </p>
+
+  <ul class="flex flex-wrap gap-[var(--spacing-xs)] pt-[var(--spacing-s)] border-t border-[var(--color-neutral-200)]">
+    {
+      featureOrder.map((key) => {
+        const has = features[key];
+        const base =
+          "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 ty-small font-medium";
+        const yes =
+          "border-[color-mix(in_oklab,var(--color-brand-swiss)_30%,transparent)] bg-[color-mix(in_oklab,var(--color-brand-swiss)_8%,transparent)] text-[var(--color-brand-deep-blue)]";
+        const no =
+          "border-[var(--color-neutral-300)] bg-transparent text-[var(--color-neutral-500)]";
+        return (
+          <li class={`${base} ${has ? yes : no}`}>
+            {has ? (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+                class="h-3.5 w-3.5 shrink-0 text-[var(--color-brand-swiss)]"
+              >
+                <path d="M9 16.2l-3.5-3.6L4 14.1 9 19l11-11-1.5-1.5z" />
+              </svg>
+            ) : (
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+                class="h-3.5 w-3.5 shrink-0 text-[var(--color-neutral-400)]"
+              >
+                <path d="M18.3 5.7L12 12l6.3 6.3-1.4 1.4L10.6 13.4 4.3 19.7l-1.4-1.4L9.2 12 2.9 5.7l1.4-1.4L10.6 10.6l6.3-6.3z" />
+              </svg>
+            )}
+            <span>{labels[key]}</span>
+          </li>
+        );
+      })
+    }
+  </ul>
+</article>

--- a/src/components/Frontends/FrontendsWarning.astro
+++ b/src/components/Frontends/FrontendsWarning.astro
@@ -1,0 +1,43 @@
+---
+interface Props {
+  eyebrow: string;
+  title: string;
+  body: string;
+}
+
+const { eyebrow, title, body } = Astro.props as Props;
+---
+
+<div
+  role="note"
+  aria-labelledby="frontends-warning-title"
+  class="rounded-xl border-2 border-[#dc2626] bg-[color-mix(in_oklab,#dc2626_8%,var(--color-white))] p-[var(--spacing-xl)] md:p-[var(--spacing-xxl)]"
+>
+  <div class="flex items-start gap-[var(--spacing-l)]">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      class="h-8 w-8 shrink-0 text-[#dc2626] mt-1"
+    >
+      <path
+        d="M12 2L1 21h22L12 2zm0 5.3l8.4 14.5H3.6L12 7.3zM11 10v5h2v-5h-2zm0 6v2h2v-2h-2z"
+      />
+    </svg>
+    <div class="flex flex-col gap-[var(--spacing-s)]">
+      <p class="ty-subtitle text-[#dc2626] font-bold">
+        {eyebrow.toUpperCase()}
+      </p>
+      <h2
+        id="frontends-warning-title"
+        class="ty-title-3 text-[#7f1d1d] m-0 font-extrabold"
+      >
+        {title}
+      </h2>
+      <p class="ty-body-1 text-[var(--color-neutral-700)]">
+        {body}
+      </p>
+    </div>
+  </div>
+</div>

--- a/src/content/de/frontends.json
+++ b/src/content/de/frontends.json
@@ -1,0 +1,30 @@
+{
+	"seo": {
+		"title": "Frankencoin Frontends — Unabhängige ZCHF-Oberflächen",
+		"description": "Frankencoin ist ein offenes Protokoll ohne offizielles Frontend. Hier finden Sie die unabhängigen Dapps zum Prägen, Sparen und Handeln mit ZCHF — jede betrieben von eigenen Maintainern, mit Quellcode und transparenter Infrastruktur."
+	},
+	"header": {
+		"title": "Frankencoin Frontends",
+		"subtitle": "Frankencoin ist ein offenes Protokoll. Jede und jeder kann ein Frontend dafür bauen und betreiben — ein offizielles gibt es nicht. Jede der unten aufgeführten Oberflächen wird unabhängig von ihren Betreibern unterhalten."
+	},
+	"warning": {
+		"eyebrow": "Wichtiger Hinweis",
+		"title": "Frontends werden von unabhängigen Dritten gebaut und ohne Gewährleistung bereitgestellt.",
+		"body": "Jedes Frontend wird unabhängig gebaut und gehostet. Nur als Information aufgeführt — nicht auditiert und ohne Gewährleistung. Nutzung auf eigenes Risiko; prüfen Sie den Quellcode, bevor Sie eine Wallet verbinden."
+	},
+	"addYours": {
+		"before": "Du betreibst dein eigenes Frontend? Füge es zur ",
+		"linkLabel": "frontends.json",
+		"after": " hinzu und eröffne einen Pull Request, um in dieser Liste zu erscheinen."
+	},
+	"labels": {
+		"creator": "Gebaut von",
+		"repo": "Quellcode",
+		"live": "Frontend öffnen",
+		"features": "Eigenschaften",
+		"openSource": "Open Source",
+		"ownDomain": "Eigene Domain",
+		"selfHostedApi": "Eigene API",
+		"selfHostedIndexer": "Eigener Indexer"
+	}
+}

--- a/src/content/de/index.json
+++ b/src/content/de/index.json
@@ -73,6 +73,11 @@
 	"core_features": {
 		"eyebrow": "Anwendungsmöglichkeiten",
 		"title": "Zahlen. Leihen. Verdienen. Bauen.",
+		"frontendsCallout": {
+			"title": "Zugang zum Frankencoin-Protokoll",
+			"body": "Mehrere unabhängige Frontends geben Zugang zu Frankencoin – darunter eines vom Frankencoin Verein.",
+			"ctaLabel": "Frontends ansehen"
+		},
 		"features": [
 			{
 				"title": "Zahlen",

--- a/src/content/de/shared/footer.json
+++ b/src/content/de/shared/footer.json
@@ -119,6 +119,10 @@
             "external": true
           },
           {
+            "label": "Frontends",
+            "href": "/frontends"
+          },
+          {
             "label": "Veranstaltungen",
             "href": "https://luma.com/user/frankencoin",
             "external": true

--- a/src/content/en/frontends.json
+++ b/src/content/en/frontends.json
@@ -1,0 +1,30 @@
+{
+	"seo": {
+		"title": "Frankencoin Frontends — Independent ZCHF interfaces",
+		"description": "Frankencoin is an open protocol with no official frontend. Browse the independent dapps for minting, saving, and trading ZCHF — each operated by its own maintainers, listed with source code and infrastructure transparency."
+	},
+	"header": {
+		"title": "Frankencoin Frontends",
+		"subtitle": "Frankencoin is an open protocol. Anyone can build and host a frontend to it — there is no official one. Every interface listed below is operated independently by its maintainers."
+	},
+	"warning": {
+		"eyebrow": "Important notice",
+		"title": "Frontends are built by independent third parties and come with no warranty.",
+		"body": "Each frontend is built and hosted independently. Listed for information only — not audited and not warranted. Use at your own risk and verify the source code before connecting a wallet."
+	},
+	"addYours": {
+		"before": "Hosting your own frontend? Add it to ",
+		"linkLabel": "frontends.json",
+		"after": " and open a pull request to get listed."
+	},
+	"labels": {
+		"creator": "Built by",
+		"repo": "Source code",
+		"live": "Open frontend",
+		"features": "Features",
+		"openSource": "Open source",
+		"ownDomain": "Own domain",
+		"selfHostedApi": "Self-hosted API",
+		"selfHostedIndexer": "Self-hosted indexer"
+	}
+}

--- a/src/content/en/index.json
+++ b/src/content/en/index.json
@@ -72,6 +72,11 @@
 	"core_features": {
 		"eyebrow": "Ways to Use Frankencoin",
 		"title": "Pay. Borrow. Earn. Build.",
+		"frontendsCallout": {
+			"title": "How to access the Frankencoin protocol",
+			"body": "Several independent frontends let you use Frankencoin — including one built by the Frankencoin Association.",
+			"ctaLabel": "Browse Frontends"
+		},
 		"features": [
 			{
 				"title": "Pay",

--- a/src/content/en/shared/footer.json
+++ b/src/content/en/shared/footer.json
@@ -119,6 +119,10 @@
             "external": true
           },
           {
+            "label": "Frontends",
+            "href": "/frontends"
+          },
+          {
             "label": "Upcoming Events",
             "href": "https://luma.com/frankencoin",
             "external": true

--- a/src/content/fr/frontends.json
+++ b/src/content/fr/frontends.json
@@ -1,0 +1,30 @@
+{
+	"seo": {
+		"title": "Frankencoin Frontends — Interfaces ZCHF indépendantes",
+		"description": "Frankencoin est un protocole ouvert sans interface officielle. Découvrez les dapps indépendantes pour émettre, épargner et échanger le ZCHF — chacune exploitée par ses propres mainteneurs, avec code source et infrastructure transparents."
+	},
+	"header": {
+		"title": "Frankencoin Frontends",
+		"subtitle": "Frankencoin est un protocole ouvert. N'importe qui peut construire et héberger une interface — il n'y en a pas d'officielle. Chacune des interfaces listées ci-dessous est exploitée de manière indépendante par ses mainteneurs."
+	},
+	"warning": {
+		"eyebrow": "Avis important",
+		"title": "Les interfaces sont construites par des tiers indépendants et fournies sans garantie.",
+		"body": "Chaque interface est construite et hébergée de manière indépendante. Listée à titre informatif — non auditée et sans garantie. Utilisation à vos risques et périls ; vérifiez le code source avant de connecter un portefeuille."
+	},
+	"addYours": {
+		"before": "Vous hébergez votre propre interface ? Ajoutez-la à ",
+		"linkLabel": "frontends.json",
+		"after": " et ouvrez une pull request pour figurer dans cette liste."
+	},
+	"labels": {
+		"creator": "Réalisée par",
+		"repo": "Code source",
+		"live": "Ouvrir l'interface",
+		"features": "Caractéristiques",
+		"openSource": "Open source",
+		"ownDomain": "Domaine propre",
+		"selfHostedApi": "API auto-hébergée",
+		"selfHostedIndexer": "Indexeur auto-hébergé"
+	}
+}

--- a/src/content/fr/index.json
+++ b/src/content/fr/index.json
@@ -73,6 +73,11 @@
 	"core_features": {
 		"eyebrow": "Cas d'utilisation",
 		"title": "Payer. Emprunter. Gagner. Construire.",
+		"frontendsCallout": {
+			"title": "Comment accéder au protocole Frankencoin",
+			"body": "Plusieurs interfaces indépendantes permettent d'utiliser Frankencoin — dont une construite par l'Association Frankencoin.",
+			"ctaLabel": "Voir les interfaces"
+		},
 		"features": [
 			{
 				"title": "Payer",

--- a/src/content/fr/shared/footer.json
+++ b/src/content/fr/shared/footer.json
@@ -119,6 +119,10 @@
             "external": true
           },
           {
+            "label": "Interfaces",
+            "href": "/frontends"
+          },
+          {
             "label": "Événements à venir",
             "href": "https://luma.com/user/frankencoin",
             "external": true

--- a/src/content/shared/frontends.json
+++ b/src/content/shared/frontends.json
@@ -1,0 +1,60 @@
+{
+	"frontends": [
+		{
+			"name": "app.frankencoin.com",
+			"url": "https://app.frankencoin.com",
+			"creator": "Frankencoin Association",
+			"creatorUrl": "https://github.com/Frankencoin-ZCHF",
+			"repo": "https://github.com/Frankencoin-ZCHF/frankencoin-dapp",
+			"notes": "Frontend built by the Frankencoin Association. Connect a wallet to mint and repay positions, access savings, and trade FPS. Source code and indexer are public.",
+			"features": {
+				"openSource": true,
+				"ownDomain": true,
+				"selfHostedApi": true,
+				"selfHostedIndexer": true
+			}
+		},
+		{
+			"name": "zchf.app",
+			"url": "https://zchf.app",
+			"creator": "dnbjn",
+			"creatorUrl": "https://github.com/dnbjn",
+			"repo": "https://github.com/dnbjn/frankencoin-dapp",
+			"notes": "Self-hosted frontend, API, and Ponder indexer. Reworked UI with dark/light mode, added host information on the Earn page, and routes indexer access through a failover-enabled API. Deployed on Railway behind a Cloudflare Tunnel.",
+			"features": {
+				"openSource": true,
+				"ownDomain": true,
+				"selfHostedApi": true,
+				"selfHostedIndexer": true
+			}
+		},
+		{
+			"name": "frankencoin.pages.dev",
+			"url": "https://frankencoin.pages.dev",
+			"creator": "dennaki",
+			"creatorUrl": "https://github.com/dennaki",
+			"repo": "https://github.com/DiumPay/zchf-app",
+			"notes": "Independent fork built by the DiumPay team, hosted on Cloudflare Pages. Includes a community German translation.",
+			"features": {
+				"openSource": true,
+				"ownDomain": true,
+				"selfHostedApi": false,
+				"selfHostedIndexer": false
+			}
+		},
+		{
+			"name": "dasabami.com",
+			"url": "https://www.dasabami.com",
+			"creator": "socraticblock",
+			"creatorUrl": "https://github.com/socraticblock",
+			"repo": "https://github.com/socraticblock/frankencoin-dapp",
+			"notes": "Open-source fork by socraticblock, in development. Currently relies on the canonical API and indexer; the maintainer plans to self-host the Ponder indexer later.",
+			"features": {
+				"openSource": true,
+				"ownDomain": true,
+				"selfHostedApi": false,
+				"selfHostedIndexer": false
+			}
+		}
+	]
+}

--- a/src/pages/[lang]/frontends.astro
+++ b/src/pages/[lang]/frontends.astro
@@ -1,0 +1,12 @@
+---
+import MainFrontends from '../frontends.astro';
+
+export function getStaticPaths() {
+  return [
+    { params: { lang: 'de' } },
+    // { params: { lang: 'fr' } }, // French temporarily disabled
+  ];
+}
+---
+
+<MainFrontends />

--- a/src/pages/frontends.astro
+++ b/src/pages/frontends.astro
@@ -1,0 +1,88 @@
+---
+import Section from "../components/Layout/Section.astro";
+import SectionHeader from "../components/Layout/SectionHeader.astro";
+import FlexStack from "../components/Layout/FlexStack.astro";
+import Base from "../layouts/Base.astro";
+import FrontendCard from "../components/Frontends/FrontendCard.astro";
+import FrontendsWarning from "../components/Frontends/FrontendsWarning.astro";
+import {
+  getLanguageFromURL,
+  loadContent,
+  loadGlobalSharedContent,
+} from "../utils/i18n";
+
+const currentLang = getLanguageFromURL(Astro.url.pathname);
+const content = await loadContent("frontends", currentLang);
+const data = await loadGlobalSharedContent<{ frontends: any[] }>("frontends");
+
+// Shuffle at build time so no frontend gets permanent top-billing.
+const frontends = [...data.frontends];
+for (let i = frontends.length - 1; i > 0; i--) {
+  const j = Math.floor(Math.random() * (i + 1));
+  [frontends[i], frontends[j]] = [frontends[j], frontends[i]];
+}
+---
+
+<Base
+  title={content.seo.title}
+  description={content.seo.description}
+>
+  <Section
+    variant="accent"
+    align="left"
+    pad="xs"
+    id="frontends-header"
+  >
+    <div class="flex flex-col gap-[var(--spacing-l)] max-w-4xl mx-auto">
+      <SectionHeader
+        title={content.header.title}
+        subtitle={content.header.subtitle}
+        maxWidth="2xl"
+        size="display"
+        align="center"
+        margin="none"
+        padding="md"
+      />
+      <FrontendsWarning
+        eyebrow={content.warning.eyebrow}
+        title={content.warning.title}
+        body={content.warning.body}
+      />
+    </div>
+  </Section>
+
+  <Section
+    variant="plain"
+    align="left"
+    pad="xs"
+    id="frontends-list"
+  >
+    <div class="max-w-4xl mx-auto">
+      <p class="ty-body-2 text-[var(--color-neutral-650)] mb-[var(--spacing-xl)] italic">
+        {content.addYours.before}
+        <a
+          href="https://github.com/Frankencoin-ZCHF/frankencoin-site/tree/main/src/content/shared/frontends.json"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="not-italic text-[var(--color-brand-deep-blue)] hover:text-[var(--color-brand-swiss)] underline font-semibold"
+        >{content.addYours.linkLabel}</a>{content.addYours.after}
+      </p>
+      <FlexStack direction="col" gap="24px">
+        {
+          frontends.map((f) => (
+            <FrontendCard
+              name={f.name}
+              url={f.url}
+              creator={f.creator}
+              creatorUrl={f.creatorUrl}
+              repo={f.repo}
+              notes={f.notes}
+              features={f.features}
+              labels={content.labels}
+            />
+          ))
+        }
+      </FlexStack>
+    </div>
+  </Section>
+</Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -155,6 +155,25 @@ Astro.response.headers.set('Cache-Control', 'public, max-age=300, s-maxage=300')
     margin="lg:mt-20 mt-60"
   >
     <FeaturesContainer features={index.core_features.features} />
+    <aside
+      class="mt-8 rounded-xl border border-[color-mix(in_oklab,var(--color-brand-deep-blue)_25%,transparent)] bg-[color-mix(in_oklab,var(--color-brand-deep-blue)_4%,var(--color-white))] p-[var(--spacing-xl)] md:p-[var(--spacing-xxl)] flex flex-col md:flex-row md:items-center md:justify-between gap-[var(--spacing-l)]"
+    >
+      <div class="flex flex-col gap-[var(--spacing-xs)] max-w-2xl">
+        <h3 class="ty-title-3 text-[var(--color-brand-deep-blue)] m-0 font-bold">
+          {index.core_features.frontendsCallout.title}
+        </h3>
+        <p class="ty-body-1 text-[var(--color-neutral-700)]">
+          {index.core_features.frontendsCallout.body}
+        </p>
+      </div>
+      <a
+        href={getLocalizedPath('/frontends', currentLang)}
+        class="inline-flex items-center gap-2 text-[var(--color-brand-deep-blue)] hover:text-[var(--color-brand-swiss)] font-bold ty-body-1 shrink-0 whitespace-nowrap"
+      >
+        <span>{index.core_features.frontendsCallout.ctaLabel}</span>
+        <img src="/images/Arrow.svg" loading="lazy" alt="" class="w-3 h-3" />
+      </a>
+    </aside>
     <div class="mt-12">
       <UseCasesGrid />
     </div>


### PR DESCRIPTION
- New /frontends page lists all independent dapps (en/de/fr) with a red "no warranty" notice, build-time shuffled order, feature chips (open source, own domain, self-hosted API/indexer), and per-frontend creator + repo links.
- Frontends data lives in src/content/shared/frontends.json so contributors can add their own via PR.
- Home page core-features section gets a callout below the four tiles linking to /frontends.
- Footer adds a "Frontends" link in the Community column for all languages.