### PR TITLE
Add Frankencoin Frontends page + home page callout

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -31,7 +31,6 @@ const site = await loadSharedContent("site", currentLang);
 
     <!-- Favicons -->
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
-    <link rel="icon" type="image/svg+xml" href="/images/Frankencoin-App-Logo.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
     <link rel="apple-touch-icon" sizes="256x256" href="/images/webclip.png" />
     <link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION
## Summary
- New `/frontends` page listing every independent dapp for the protocol (app.frankencoin.com, zchf.app, frankencoin.pages.dev, dasabami.com), localized EN/DE/FR, with a red no-warranty notice, build-time shuffled order, feature chips (open source / own domain / self-hosted API / self-hosted indexer), and per-frontend creator + repo links.
- Data lives in `src/content/shared/frontends.json` so contributors can add their own via PR; the page links the file directly.
- Home page core-features section gets a "How to access the Frankencoin protocol" callout below the four feature tiles.
- Footer adds a "Frontends" link in the Community column (EN/DE/FR).
- Drive-by fix: removed the wordmark SVG favicon override, so browsers use the existing square `favicon.ico`/`favicon.png` instead of squishing the 268×30 wordmark into 16×16.

## Test plan
- [ ] `/frontends` renders correctly in EN, DE, FR (footer "Frontends" link works in each)
- [ ] Frontend cards display feature chips and buttons; order reshuffles between builds
- [ ] Home page callout appears below the 4 feature tiles and links to `/frontends` (language-prefixed)
- [ ] Browser tab shows the grey-coin favicon on every page
- [ ] No 404s and no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)