### PR TITLE
docs(frontends): add Frankenport to frontends listing

### DIFF
--- a/src/content/shared/frontends.json
+++ b/src/content/shared/frontends.json
@@ -55,6 +55,20 @@
 				"selfHostedApi": false,
 				"selfHostedIndexer": false
 			}
+		},
+		{
+			"name": "frankenport.com",
+			"url": "https://frankenport.com",
+			"creator": "loomi-labs",
+			"creatorUrl": "https://github.com/loomi-labs",
+			"repo": "https://github.com/loomi-labs/frankencoin-dapp",
+			"notes": "Self-hosted frontend and API on Hetzner behind a Cloudflare proxy, using the canonical Ponder indexer. Elegant and clean design with a Swiss palette.",
+			"features": {
+				"openSource": true,
+				"ownDomain": true,
+				"selfHostedApi": true,
+				"selfHostedIndexer": false
+			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- Add **Frankenport** (https://frankenport.com) to the community frontends listing in `src/content/shared/frontends.json`.
- Repo: https://github.com/loomi-labs/frankencoin-dapp (MIT).
- Self-hosted frontend and API on Hetzner behind a Cloudflare proxy, using the canonical Ponder indexer. Feature flags `openSource`, `ownDomain`, and `selfHostedApi` are `true`; `selfHostedIndexer` is `false`.