### PR TITLE
Add bug bounty link to audit section

### DIFF
--- a/src/components/TrustSecurityContainer/TrustSecurityContainer.astro
+++ b/src/components/TrustSecurityContainer/TrustSecurityContainer.astro
@@ -132,6 +132,9 @@ const pharosUpdatedAt = pharosRating?.updatedAt
     </div>
     {index.trust_security.audits.bugBounty && (
       <div class="mt-6">
+        <p class="ty-small text-[var(--color-brand-titan-gray)] max-w-2xl mb-2">
+          {index.trust_security.audits.bugBounty.description}
+        </p>
         <a
           href={index.trust_security.audits.bugBounty.href}
           target="_blank"
@@ -141,9 +144,6 @@ const pharosUpdatedAt = pharosRating?.updatedAt
           <span>{index.trust_security.audits.bugBounty.label}</span>
           <img src="/images/Arrow.svg" loading="lazy" alt="" class="w-3 h-3" />
         </a>
-        <p class="ty-small text-[var(--color-brand-titan-gray)] mt-2 max-w-2xl">
-          {index.trust_security.audits.bugBounty.description}
-        </p>
       </div>
     )}
   </div>

--- a/src/components/TrustSecurityContainer/TrustSecurityContainer.astro
+++ b/src/components/TrustSecurityContainer/TrustSecurityContainer.astro
@@ -141,6 +141,9 @@ const pharosUpdatedAt = pharosRating?.updatedAt
           <span>{index.trust_security.audits.bugBounty.label}</span>
           <img src="/images/Arrow.svg" loading="lazy" alt="" class="w-3 h-3" />
         </a>
+        <p class="ty-small text-[var(--color-brand-titan-gray)] mt-2 max-w-2xl">
+          {index.trust_security.audits.bugBounty.description}
+        </p>
       </div>
     )}
   </div>

--- a/src/components/TrustSecurityContainer/TrustSecurityContainer.astro
+++ b/src/components/TrustSecurityContainer/TrustSecurityContainer.astro
@@ -130,6 +130,19 @@ const pharosUpdatedAt = pharosRating?.updatedAt
         </a>
       ))}
     </div>
+    {index.trust_security.audits.bugBounty && (
+      <div class="mt-6">
+        <a
+          href={index.trust_security.audits.bugBounty.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-2 ty-regular text-[var(--color-brand-deep-blue)] hover:text-[var(--color-brand-swiss)] hover:underline font-bold"
+        >
+          <span>{index.trust_security.audits.bugBounty.label}</span>
+          <img src="/images/Arrow.svg" loading="lazy" alt="" class="w-3 h-3" />
+        </a>
+      </div>
+    )}
   </div>
 
   <!-- Ratings Section -->

--- a/src/content/de/index.json
+++ b/src/content/de/index.json
@@ -289,6 +289,7 @@
 			"description": "Frankencoin und alle hinzugefügten Komponenten wurden von führenden Blockchain Security Firms geprüft. Die Audits umfassen Smart-Contract-Sicherheit, ökonomisches Design und die Gesamtintegrität des Systems, um eine robuste und sichere Plattform für Nutzer zu gewährleisten.",
 			"bugBounty": {
 				"label": "Bug-Bounty-Programm",
+				"description": "Melden Sie potenzielle Smart-Contract- oder Protokoll-Sicherheitslücken über das Compass Security Bug-Bounty-Programm.",
 				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
 			},
 			"partners": [

--- a/src/content/de/index.json
+++ b/src/content/de/index.json
@@ -289,7 +289,7 @@
 			"description": "Frankencoin und alle hinzugefügten Komponenten wurden von führenden Blockchain Security Firms geprüft. Die Audits umfassen Smart-Contract-Sicherheit, ökonomisches Design und die Gesamtintegrität des Systems, um eine robuste und sichere Plattform für Nutzer zu gewährleisten.",
 			"bugBounty": {
 				"label": "Bug-Bounty-Programm",
-				"description": "Melden Sie potenzielle Smart-Contract- oder Protokoll-Sicherheitslücken über das Compass Security Bug-Bounty-Programm.",
+				"description": "Zusätzlich zu den Audits bietet die Frankencoin Association Bounties für die Offenlegung von Bugs an, welche die Stabilität des Systems beeinträchtigen. Das Programm wird von Compass Security betreut; Details finden Sie hier:",
 				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
 			},
 			"partners": [

--- a/src/content/de/index.json
+++ b/src/content/de/index.json
@@ -287,6 +287,10 @@
 		"audits": {
 			"title": "Technical Audits",
 			"description": "Frankencoin und alle hinzugefügten Komponenten wurden von führenden Blockchain Security Firms geprüft. Die Audits umfassen Smart-Contract-Sicherheit, ökonomisches Design und die Gesamtintegrität des Systems, um eine robuste und sichere Plattform für Nutzer zu gewährleisten.",
+			"bugBounty": {
+				"label": "Bug-Bounty-Programm",
+				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
+			},
 			"partners": [
 				{
 					"altText": "Code4rena",

--- a/src/content/en/index.json
+++ b/src/content/en/index.json
@@ -289,6 +289,7 @@
 			"description": "The Frankencoin and each added component has been audited by leading blockchain security firms. The audits cover smart contract security, economic design, and overall system integrity to ensure a robust and secure platform for users.",
 			"bugBounty": {
 				"label": "Bug bounty programme",
+				"description": "Report potential smart contract or protocol security vulnerabilities through the Compass Security bug bounty programme.",
 				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
 			},
 			"partners": [

--- a/src/content/en/index.json
+++ b/src/content/en/index.json
@@ -289,7 +289,7 @@
 			"description": "The Frankencoin and each added component has been audited by leading blockchain security firms. The audits cover smart contract security, economic design, and overall system integrity to ensure a robust and secure platform for users.",
 			"bugBounty": {
 				"label": "Bug bounty programme",
-				"description": "Report potential smart contract or protocol security vulnerabilities through the Compass Security bug bounty programme.",
+				"description": "Apart from the audits, the Frankencoin Association is offering bounties for the disclosure of bugs affecting the stability of the system. The programme is handled by Compass Security and details can be found here:",
 				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
 			},
 			"partners": [

--- a/src/content/en/index.json
+++ b/src/content/en/index.json
@@ -287,6 +287,10 @@
 		"audits": {
 			"title": "Technical Audits",
 			"description": "The Frankencoin and each added component has been audited by leading blockchain security firms. The audits cover smart contract security, economic design, and overall system integrity to ensure a robust and secure platform for users.",
+			"bugBounty": {
+				"label": "Bug bounty programme",
+				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
+			},
 			"partners": [
 				{
 					"altText": "Code4rena",

--- a/src/content/fr/index.json
+++ b/src/content/fr/index.json
@@ -286,6 +286,7 @@
 			"description": "Audité par des security firms blockchain de premier plan pour garantir l'intégrité du protocole",
 			"bugBounty": {
 				"label": "Programme de bug bounty",
+				"description": "Signalez les vulnérabilités potentielles des smart contracts ou du protocole via le programme de bug bounty de Compass Security.",
 				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
 			},
 			"partners": [

--- a/src/content/fr/index.json
+++ b/src/content/fr/index.json
@@ -286,7 +286,7 @@
 			"description": "Audité par des security firms blockchain de premier plan pour garantir l'intégrité du protocole",
 			"bugBounty": {
 				"label": "Programme de bug bounty",
-				"description": "Signalez les vulnérabilités potentielles des smart contracts ou du protocole via le programme de bug bounty de Compass Security.",
+				"description": "En plus des audits, la Frankencoin Association offre des primes pour la divulgation de bugs affectant la stabilité du système. Le programme est géré par Compass Security; les détails sont disponibles ici :",
 				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
 			},
 			"partners": [

--- a/src/content/fr/index.json
+++ b/src/content/fr/index.json
@@ -284,6 +284,10 @@
 		"audits": {
 			"title": "Security Audits",
 			"description": "Audité par des security firms blockchain de premier plan pour garantir l'intégrité du protocole",
+			"bugBounty": {
+				"label": "Programme de bug bounty",
+				"href": "https://bugbounty.compass-security.com/service-details.html?id=18"
+			},
 			"partners": [
 				{
 					"altText": "Code4rena",


### PR DESCRIPTION
## Summary
- Add Compass Security bug bounty programme link under the Technical Audits section
- Add localized labels for EN/DE/FR

## Validation
- npm run build