### PR TITLE
Add Base svZCHF token

### DIFF
--- a/src/content/de/token.json
+++ b/src/content/de/token.json
@@ -181,6 +181,24 @@
 				]
 			},
 			{
+				"name": "Base",
+				"image": "/images/Coin_Logo_Frankencoin_saved.svg",
+				"contract": "0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585",
+				"explorerBaseUrl": "https://basescan.org/address",
+				"actions": [
+					{
+						"label": "Bungee Swap UI verwenden",
+						"image": "/images/Bungee Full Logo Black.svg",
+						"href": "https://www.bungee.exchange/?fromChainId=8453&fromTokenAddress=0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585&toChainId=8453&toTokenAddress=0xd4dd9e2f021bb459d5a5f6c24c12fe09c5d45553"
+					},
+					{
+						"label": "Direkt onchain verwenden",
+						"image": "/images/Frankencoin-eth-base.webp",
+						"href": "https://basescan.org/address/0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585#writeContract"
+					}
+				]
+			},
+			{
 				"name": "Gnosis",
 				"image": "/images/Coin_Logo_Frankencoin_saved.svg",
 				"contract": "0x6165946250dd04740ab1409217e95a4f38374fe9",

--- a/src/content/en/token.json
+++ b/src/content/en/token.json
@@ -181,6 +181,24 @@
 				]
 			},
 			{
+				"name": "Base",
+				"image": "/images/Coin_Logo_Frankencoin_saved.svg",
+				"contract": "0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585",
+				"explorerBaseUrl": "https://basescan.org/address",
+				"actions": [
+					{
+						"label": "Use Bungee Swap UI",
+						"image": "/images/Bungee Full Logo Black.svg",
+						"href": "https://www.bungee.exchange/?fromChainId=8453&fromTokenAddress=0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585&toChainId=8453&toTokenAddress=0xd4dd9e2f021bb459d5a5f6c24c12fe09c5d45553"
+					},
+					{
+						"label": "Use directly onchain",
+						"image": "/images/Frankencoin-eth-base.webp",
+						"href": "https://basescan.org/address/0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585#writeContract"
+					}
+				]
+			},
+			{
 				"name": "Gnosis",
 				"image": "/images/Coin_Logo_Frankencoin_saved.svg",
 				"contract": "0x6165946250dd04740ab1409217e95a4f38374fe9",

--- a/src/content/fr/token.json
+++ b/src/content/fr/token.json
@@ -181,6 +181,24 @@
 				]
 			},
 			{
+				"name": "Base",
+				"image": "/images/Coin_Logo_Frankencoin_saved.svg",
+				"contract": "0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585",
+				"explorerBaseUrl": "https://basescan.org/address",
+				"actions": [
+					{
+						"label": "Utiliser l'interface Bungee Swap",
+						"image": "/images/Bungee Full Logo Black.svg",
+						"href": "https://www.bungee.exchange/?fromChainId=8453&fromTokenAddress=0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585&toChainId=8453&toTokenAddress=0xd4dd9e2f021bb459d5a5f6c24c12fe09c5d45553"
+					},
+					{
+						"label": "Utiliser directement onchain",
+						"image": "/images/Frankencoin-eth-base.webp",
+						"href": "https://basescan.org/address/0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585#writeContract"
+					}
+				]
+			},
+			{
 				"name": "Gnosis",
 				"image": "/images/Coin_Logo_Frankencoin_saved.svg",
 				"contract": "0x6165946250dd04740ab1409217e95a4f38374fe9",


### PR DESCRIPTION
## Summary
- Add Base svZCHF to the token page savings vault section in EN/DE/FR content.
- Link BaseScan contract page and Base Bungee route for svZCHF → ZCHF.

## Validation
- `python3 -m json.tool src/content/en/token.json`
- `python3 -m json.tool src/content/de/token.json`
- `python3 -m json.tool src/content/fr/token.json`
- `npm run build`
- Verified BaseScan address page contains svZCHF.
