### PR TITLE
Add security.txt

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,24 @@
+# In case of security incidents please contact the
+
+# Frankencoin Association
+
+Contact: mailto: info@frankencoin.com
+
+ 
+
+# For vulnerability reports please contact the Compass Security Bug Bounty Team
+
+Contact: https://bugbounty.compass-security.com/bug-bounties/frankencoin-bug-bounty
+
+Policy: https://bugbounty.compass-security.com/bug-bounties/frankencoin-bug-bounty
+
+ 
+
+Expires: 2027-12-20T00:00:00.000Z
+
+Preferred-Languages: en, de
+
+
+# Note
+
+It was decided to allow integration of Frankencoin into external pages to support decentralization and cross-domain embedding. While aware of potential security risks (e.g., clickjacking), this model was chosen deliberately. Users are responsible for verifying transaction data, especially with non-open-source integrations.


### PR DESCRIPTION
## Summary
- Add `.well-known/security.txt` from the legacy website to the new Astro site public assets
- Keeps Frankencoin and Compass Security bug bounty contact/policy information available at `/.well-known/security.txt`

## Validation
- `npm run build`
- verified `dist/client/.well-known/security.txt` is generated